### PR TITLE
State as an arg

### DIFF
--- a/demo01_stopping.py
+++ b/demo01_stopping.py
@@ -2,6 +2,7 @@
 
 TEAM_NAME = 'StoppingBots'
 
-def move(turn, game):
+def move(bot, state):
     # do not move at all
-    return (0,0)
+    next_move = (0,0)
+    return next_move, state

--- a/demo02_random.py
+++ b/demo02_random.py
@@ -3,8 +3,8 @@
 
 TEAM_NAME = 'RandomBots'
 
-def move(turn, game):
+def move(bot, state):
     # make a reference to our bot with a shorter name
     # mostly useful for longer code, of course
-    bot = game.team[turn]
-    return bot.random.choice(bot.legal_moves)
+    next_move = bot.random.choice(bot.legal_moves)
+    return next_move, state

--- a/demo03_smartrandom.py
+++ b/demo03_smartrandom.py
@@ -5,9 +5,7 @@
 # - avoids going back to positions it has seen already
 TEAM_NAME = 'SmartRandomBots'
 
-def move(turn, game):
-    bot = game.team[turn]
-
+def move(bot, state):
     # get a tuple with our enemy positions
     enemy_pos = (bot.enemy[0].position, bot.enemy[1].position)
 
@@ -62,4 +60,4 @@ def move(turn, game):
         # so just stop here and hope for the best
         next_move = (0,0)
 
-    return next_move
+    return next_move, state

--- a/demo04_basic_attacker.py
+++ b/demo04_basic_attacker.py
@@ -9,30 +9,29 @@ from pelita.utils import Graph
 
 from utils import next_step
 
-def move(turn, game):
-    bot = game.team[turn]
+def move(bot, state):
     # we need to create a dictionary to keep information (state) along rounds
-    # the game.state object will be passed untouched at every new round
-    if game.state is None:
+    # the state object will be passed untouched at every new round
+    if state is None:
         # initialize the state dictionary
-        game.state = {}
+        state = {}
         # each bot needs its own state dictionary to keep track of the
         # food targets
-        game.state[0] = None
-        game.state[1] = None
+        state[0] = None
+        state[1] = None
         # initialize a graph representation of the maze
         # this can be shared among our bots
-        game.state['graph'] = Graph(bot.position, bot.walls)
+        state['graph'] = Graph(bot.position, bot.walls)
 
-    target = game.state[turn]
+    target = state[bot.turn]
 
     # choose a target food pellet if we still don't have one or
     # if the old target has been already eaten
     if (target is None) or (target not in bot.enemy[0].food):
-        target = game.state[turn] = bot.random.choice(bot.enemy[0].food)
+        target = state[bot.turn] = bot.random.choice(bot.enemy[0].food)
 
     # get the next position along the shortest path to reach our target
-    next_pos = next_step(bot.position, target, game.state['graph'])
+    next_pos = next_step(bot.position, target, state['graph'])
 
     # now, let's check if we are getting too near to our enemy
     # where are the enemy ghosts?
@@ -41,7 +40,7 @@ def move(turn, game):
             # we are in the enemy zone: they can eat us!
             # 1. let's forget about this target (the enemy is sitting on it for
             #    now). We will choose a new target in the next round
-            game.state[turn] = None
+            state[turn] = None
             # 2. let us step back
             # bot.track[-1] is always the current position, so to backtrack
             # we select bot.track[-2]
@@ -52,5 +51,6 @@ def move(turn, game):
                 next_pos = bot.get_position(bot.random.choice(bot.legal_moves))
 
     # return the move needed to get from our position to the next position
-    return bot.get_move(next_pos)
+    next_move = bot.get_move(next_pos
+    return next_move, state
 

--- a/demo05_basic_defender.py
+++ b/demo05_basic_defender.py
@@ -11,13 +11,13 @@ from pelita.utils import Graph
 
 from utils import next_step
 
-def move(turn, game):
-    bot = game.team[turn]
+def move(bot, state):
 
-    if game.state is None:
+    if state is None:
         # initialize the state object to be a graph representation of the maze
-        game.state = Graph(bot.position, bot.walls)
+        state = Graph(bot.position, bot.walls)
 
+    turn = bot.turn
     if bot.enemy[0].is_noisy and bot.enemy[1].is_noisy:
         # if both enemies are noisy, just aim for our turn companion
         target = bot.enemy[turn].position
@@ -31,7 +31,7 @@ def move(turn, game):
         raise Exception('We should never be here!')
 
     # get the next step to be done to reach our target enemy bot
-    next_pos = next_step(bot.position, target, game.state)
+    next_pos = next_step(bot.position, target, state)
 
     # let's check that we don't go into the enemy homezone, i.e. stop at the
     # border
@@ -40,5 +40,5 @@ def move(turn, game):
     else:
         next_move = bot.get_move(next_pos)
 
-    return next_move
+    return next_move, state
 

--- a/demo06_one_and_one.py
+++ b/demo06_one_and_one.py
@@ -4,30 +4,18 @@ TEAM_NAME = 'one and one'
 from demo05_basic_defender import move as move_defender
 from demo04_basic_attacker import move as move_attacker
 
-def move(turn, game):
+def move(bot, state):
     # create a combined game state to collect the states for both bots
-    if game.state is None:
+    if state is None:
         # initialization
-        combined_state = {'attacker' : None, 'defender' : None}
-    else:
-        # keep a copy of the game state (the move_defender and move_attacker
-        # functions are going to overwrite game.state, so we need a copy
-        # here so that we can reset game.state before returning)
-        combined_state = game.state.copy()
+        state = {'attacker' : None, 'defender' : None}
 
-    if turn == 0:
-        # fake the game.state
-        game.state = combined_state['defender']
-        next_move = move_defender(turn, game)
-        # collect the defender state in our own dictionary
-        combined_state['defender'] = game.state
+    if bot.turn == 0:
+        # ignore returned state from defender, we store it in our
+        # state dictionary anyway
+        next_move, _ = move_defender(bot, state['defender'])
     else:
         # same as above
-        game.state = combined_state['attacker']
-        next_move = move_attacker(turn, game)
-        # collect the attacker state in our own dictionary
-        combined_state['attacker'] = game.state
+        next_move, _ = move_attacker(bot, state['attacker'])
 
-    game.state = combined_state
-
-    return next_move
+    return next_move, state

--- a/demo07_detect_death.py
+++ b/demo07_detect_death.py
@@ -4,21 +4,21 @@ TEAM_NAME = "Death Detectors Bots"
 MESSAGE = 'I am a zombie now!'
 EATEN_INERTIA = 10
 
-def move(turn, game):
-    bot = game.team[turn]
+def move(bot, state):
 
-    if game.state is None:
+    if state is None:
         # initialize a state dictionary for both bots
-        game.state = { 0:0, 1:0}
+        state = {0:0, 1:0}
 
     # check if we have benn eaten in the previous round
     if bot.eaten:
         # set the speak inertia
-        game.state[turn] = EATEN_INERTIA
-    if game.state[turn]:
+        state[bot.turn] = EATEN_INERTIA
+
+    if state[bot.turn]:
         # speak for as many rounds as EATEN_INTERTIA
         bot.say(MESSAGE)
-        game.state[turn] -= 1
+        state[turn] -= 1
 
     # copy the available moves, so that we can use random.shuffle,
     # which unfortunately shuffles lists in-place.
@@ -29,4 +29,4 @@ def move(turn, game):
         if new_pos not in bot.track:
            break
 
-    return next_move
+    return next_move, state

--- a/demo08_debugger.py
+++ b/demo08_debugger.py
@@ -6,8 +6,9 @@
 
 TEAM_NAME = 'Debuggable Bot'
 
-def move(turn, game):
+def move(bot, state):
     # in Python >= 3.7 this can be changed to simply
     # breakpoint()
     import pdb; pdb.set_trace()
-    return (0,0)
+    next_move = (0,0)
+    return next_move, state

--- a/demo09_polite_random.py
+++ b/demo09_polite_random.py
@@ -3,13 +3,11 @@
 
 TEAM_NAME = 'PoliteRandomBots'
 
-def move(turn, game):
-    bot = game.team[turn]
-    teammate = game.team[1 - turn]
+def move(bot, state):
 
     possible_moves = []
     for m in bot.legal_moves:
-        if bot.get_position(m) == teammate.position:
+        if bot.get_position(m) == bot.other.position:
             bot.say('Excuse me. Sorry. Excuse me.')
         else:
             possible_moves.append(m)
@@ -17,4 +15,5 @@ def move(turn, game):
     # - move away from our team mate if we already are in the same position, or
     # - we can stop if our only other legal move would put us in the same
     #   position as our team mate
-    return bot.random.choice(possible_moves)
+    next_move = bot.random.choice(possible_moves)
+    return next_move, state

--- a/test_demo01_stopping.py
+++ b/test_demo01_stopping.py
@@ -14,10 +14,10 @@ def test_stays_there():
     all_locations = ((x, y) for x in range(8) for y in range(4))
     for loc in all_locations:
         try:
-            game = setup_test_game(layout=layout, is_blue=True, bots=[loc])
+            bot = setup_test_game(layout=layout, is_blue=True, bots=[loc])
         except ValueError:
             # loc is a wall, skip this position
             continue
-        next_move = move(0, game)
+        next_move, _ = move(bot, None)
         assert next_move == (0,0)
 

--- a/test_demo02_random.py
+++ b/test_demo02_random.py
@@ -14,11 +14,11 @@ def test_always_legal():
     all_locations = ((x, y) for x in range(8) for y in range(4))
     for loc in all_locations:
         try:
-            game = setup_test_game(layout=layout, is_blue=True, bots=[loc])
+            bot = setup_test_game(layout=layout, is_blue=True, bots=[loc])
         except ValueError:
             # loc is a wall, skip this position
             continue
-        next_move = move(0, game)
-        legal_moves = game.team[0].legal_moves
+        next_move, _ = move(bot, None)
+        legal_moves = bot.legal_moves
         assert next_move in legal_moves
 

--- a/test_demo03_smartrandom.py
+++ b/test_demo03_smartrandom.py
@@ -11,8 +11,8 @@ def test_legalmoves():
     ########
     """
     for i in range(10):
-        game = setup_test_game(layout=layout, is_blue=True)
-        next_move = move(0, game)
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_move,_ = move(bot, None)
         assert next_move in ((0,1), (0,0))
 
 def test_eat_enemy():
@@ -23,8 +23,8 @@ def test_eat_enemy():
     #0.  1E#
     ########
     """
-    game = setup_test_game(layout=layout, is_blue=True)
-    next_move = move(0, game)
+    bot = setup_test_game(layout=layout, is_blue=True)
+    next_move, _ = move(bot, None)
     assert next_move == (0,-1)
 
 def test_eat_food():
@@ -35,8 +35,8 @@ def test_eat_food():
     #1.E 0 #
     ########
     """
-    game = setup_test_game(layout=layout, is_blue=True)
-    next_move = move(0, game)
+    bot = setup_test_game(layout=layout, is_blue=True)
+    next_move, _ = move(bot, None)
     assert next_move == (0,-1)
 
 def test_no_kamikaze_stop():
@@ -47,6 +47,6 @@ def test_no_kamikaze_stop():
     #1. E0E#
     ########
     """
-    game = setup_test_game(layout=layout, is_blue=True)
-    next_move = move(0, game)
+    bot = setup_test_game(layout=layout, is_blue=True)
+    next_move, _ = move(bot, state)
     assert next_move == (0, 0)

--- a/test_demo04_basic_attacker.py
+++ b/test_demo04_basic_attacker.py
@@ -9,8 +9,8 @@ def test_eat_food():
     #.1  EE#
     ########
     """
-    game = setup_test_game(layout=layout, is_blue=True)
-    next_move = move(0, game)
+    bot = setup_test_game(layout=layout, is_blue=True)
+    next_move, _ = move(bot, None)
     assert next_move == (1, 0)
 
 def test_no_kamikaze():
@@ -21,12 +21,11 @@ def test_no_kamikaze():
     #.1  0E#
     ########
     """
-    game = setup_test_game(layout=layout, is_blue=True)
+    bot = setup_test_game(layout=layout, is_blue=True)
     # create a "fake" track of previous moves, as our bot needs it to decide
     # where to go to avoid a bot
-    game.team[0]._track = [(4,2), (5,2)] # we use the internal attribute '_track'
-                                     # because the property 'track' is read-only
-    next_move = move(0, game)
+    bot.track = [(4,2), (5,2)]
+    next_move, _ = move(bot, None)
     assert next_move == (-1, 0)
 
 def test_shortest_path():
@@ -53,11 +52,11 @@ def test_shortest_path():
     """
     path2 = [(6, 1), (6,2), (5,2), (4,2), (3,2), (2,2), (1,2)]
     for l, p in ((layout1, path1), (layout2, path2)):
-        game = setup_test_game(layout=l, is_blue=True)
+        bot = setup_test_game(layout=l, is_blue=True)
         # we can ignore this, we just call move to have the bot generate the graph
         # representation of the maze
-        next_move = move(0, game)
-        graph = game.state['graph']
+        next_move, state = move(bot, None)
+        graph = state['graph']
         path = graph.a_star((1,1), (6,1))
         # test that the generated path is the shortest one
         assert path == p
@@ -67,7 +66,7 @@ def test_shortest_path():
         for idx, step in enumerate(path[:-1]):
             # create a layout where we are starting from the current step in
             # the path
-            game = setup_test_game(layout=l, is_blue=True, bots=[step])
-            next_move = move(0, game)
+            bot = setup_test_game(layout=l, is_blue=True, bots=[step])
+            next_move, state = move(bot, state)
             next_pos = (step[0]+next_move[0], step[1]+next_move[1])
             assert next_pos == path[idx+1]

--- a/test_demo05_basic_defender.py
+++ b/test_demo05_basic_defender.py
@@ -9,8 +9,8 @@ def test_kill_enemy():
     #.0E  E#
     ########
     """
-    game = setup_test_game(layout=layout, is_blue=True)
-    next_move = move(0, game)
+    bot = setup_test_game(layout=layout, is_blue=True)
+    next_move, _ = move(bot, None)
     assert next_move == (1, 0)
 
 def test_stop_at_the_border():
@@ -20,8 +20,8 @@ def test_stop_at_the_border():
     #    1.#
     #. 0E E#
     ########"""
-    game = setup_test_game(layout=layout, is_blue=True)
-    next_move = move(0, game)
+    bot = setup_test_game(layout=layout, is_blue=True)
+    next_move, _ = move(bot, None)
     assert next_move == (0, 0)
 
 def test_face_the_enemy():
@@ -32,7 +32,7 @@ def test_face_the_enemy():
     #  0 1.#
     #.  E E#
     ########"""
-    game = setup_test_game(layout=layout, is_blue=True)
-    next_move = move(0, game)
+    bot = setup_test_game(layout=layout, is_blue=True)
+    next_move, _ = move(bot, None)
     assert next_move == (0, 1)
 

--- a/test_demo09_polite_random.py
+++ b/test_demo09_polite_random.py
@@ -12,6 +12,6 @@ def test_nostep():
     """
     # run the test for ten random games
     for i in range(10):
-        game = setup_test_game(layout=layout, is_blue=True)
-        next_move = move(0, game)
+        bot = setup_test_game(layout=layout, is_blue=True)
+        next_move, _ = move(bot, None)
         assert next_move in ((1, 0), (0, 0))


### PR DESCRIPTION
Implementation of the third alternative for a new `state` object and removal of the `Game` object and the `Team` list from: https://github.com/ASPP/pelita/issues/529

The code is so much nicer to write, and in general shorter and more straightforward. A clear win.

I have explicitly declared the `next_move` variable even within the most trivial `move` functions, so that it is clear that the function now returns a tuple with two elements, the first is a move and the second the new `state` object.

I adapted the documentation too. It reads also more easily.

Note that changes to `setup_test_game` in pelita are also required for this to work (see the `test_demoX.py` files).

In the documentation I say that doing `print(bot)` wil print the state of the game. I think this should include the layout string and all other relevant info, for example `score`, `round`, etc...