### PR TITLE
.env file that sets up the PYTHONPATH for tests from inside VSCode

### DIFF
--- a/.env
+++ b/.env
@@ -1,0 +1,1 @@
+PYTHONPATH=.


### PR DESCRIPTION
As the pelita_template folder isn’t a proper package, `pytest` can only run the tests when invoked as `python -m pytest`, as this adds the template folder to `sys.path`. Unfortunately, the VSCode mechanism for invoking `pytest` runs it as a script and therefore our tests cannot import the `demoXX.py` files.

This `.env` file should automatically be read by VSCode (and perhaps other tools) and add the current folder to the PYTHONPATH (yeah, I also thought these days would be over).

Now running (or debugging!) tests is as simple as clicking the `Run test!` button above a function inside the editor window and waiting for the check mark to appear.
<img width="772" alt="image" src="https://user-images.githubusercontent.com/216179/123509000-4872d380-d673-11eb-981d-06a9960ced88.png">
