### PR TITLE
[DRAFT] GH actions

### DIFF
--- a/.github/workflows/pelita-runner.yaml
+++ b/.github/workflows/pelita-runner.yaml
@@ -31,12 +31,13 @@ jobs:
           echo "::set-output name=group::\"${group}\""
         else
           echo "::error::No or more than one groupN.py file found."
-          exit 1
+          echo "::set-output name=group::False"
         fi
       shell: bash
 
   run-pelita:
     name: Run pelita with player ${{fromJson(needs.detect-team.outputs.team)}}
+    if: ${{fromJson(needs.detect-team.outputs.team)}}
     needs: detect-team
     runs-on: ubuntu-latest
     strategy:

--- a/.github/workflows/pelita-runner.yaml
+++ b/.github/workflows/pelita-runner.yaml
@@ -11,6 +11,12 @@ on:
 
 jobs:
   detect-team:
+    # The detect-team job specifically looks for a file named
+    # group0.py, group1.py, ..., group4.py
+    # which it will use to search for a team that can be imported.
+    # Outside of an ASPP school (it is a requirement that the main file
+    # in the repo bears that name), this may not be useful and this job
+    # can be skipped.
     runs-on: ubuntu-latest
     outputs:
       team: ${{ steps.set-group-script.outputs.group }}

--- a/.github/workflows/pelita-runner.yaml
+++ b/.github/workflows/pelita-runner.yaml
@@ -1,0 +1,85 @@
+# This workflow will install Python dependencies, run tests and lint with a variety of Python versions
+# For more information see: https://help.github.com/actions/language-and-framework-guides/using-python-with-github-actions
+
+name: Pelita CI testing
+
+on:
+  push:
+    branches: [ master ]
+  pull_request:
+    branches: [ master ]
+
+jobs:
+  detect-team:
+    runs-on: ubuntu-latest
+    outputs:
+      team: ${{ steps.set-group-script.outputs.group }}
+    steps:
+    - uses: actions/checkout@v2
+    - name: Detect group script
+      id: set-group-script
+      # some stupid bash string array tricks there: ($( .. ))
+      run: |
+        group=($(for g in group{0,1,2,3,4}.py ; do [ -f $g ] && echo "$g" || : ; done ))
+        if [ ${#group[@]} -eq 1 ] ; then
+          echo "::set-output name=group::\"${group}\""
+        else
+          echo "::error::No or more than one groupN.py file found."
+          exit 1
+        fi
+      shell: bash
+
+  run-pelita:
+    name: Run pelita with player ${{fromJson(needs.detect-team.outputs.team)}}
+    needs: detect-team
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        python -m pip install git+https://github.com/ASPP/pelita
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Check that a the team can be imported
+      run: |
+        pelita --check-team ${{needs.detect-team.outputs.team}}
+
+  pytest:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        python-version: [3.9]
+
+    steps:
+    - uses: actions/checkout@v2
+    - name: Set up Python ${{ matrix.python-version }}
+      uses: actions/setup-python@v2
+      with:
+        python-version: ${{ matrix.python-version }}
+    - name: Install dependencies
+      run: |
+        python -m pip install --upgrade pip
+        python -m pip install flake8 pytest
+        python -m pip install git+https://github.com/ASPP/pelita
+        if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
+    - name: Lint with flake8
+      run: |
+        # stop the build if there are Python syntax errors or undefined names
+        flake8 . --count --select=E9,F63,F7,F82 --show-source --statistics
+        # exit-zero treats all errors as warnings. The GitHub editor is 127 chars wide
+        flake8 . --count --exit-zero --max-complexity=10 --max-line-length=127 --statistics
+    - name: Test with pytest
+      run: |
+        python -m pytest
+

--- a/.github/workflows/pelita-runner.yaml
+++ b/.github/workflows/pelita-runner.yaml
@@ -20,6 +20,7 @@ jobs:
     runs-on: ubuntu-latest
     outputs:
       team: ${{ steps.set-group-script.outputs.group }}
+      status: ${{ steps.set-group-script.outputs.status }}
     steps:
     - uses: actions/checkout@v2
     - name: Detect group script
@@ -29,15 +30,29 @@ jobs:
         group=($(for g in group{0,1,2,3,4}.py ; do [ -f $g ] && echo "$g" || : ; done ))
         if [ ${#group[@]} -eq 1 ] ; then
           echo "::set-output name=group::\"${group}\""
+          echo "::set-output name=status::\"Run pelita with player from file ${group}\""
         else
-          echo "::error::No or more than one groupN.py file found."
-          echo "::set-output name=group::False"
+          if [ ${#group[@]} -eq 0 ] ; then
+            echo "::error::No groupN.py file found."
+            echo "::set-output name=group::false"
+            echo "::set-output name=status::\"WARNING: No file groupN.py found. Cannot test tournament.\""
+          else
+            echo "::error::More than one groupN.py file found."
+            echo "::set-output name=status::\"Error: More than one groupN.py file found. Cannot test tournament.\""
+            exit 1
+          fi
         fi
       shell: bash
 
   run-pelita:
-    name: Run pelita with player ${{fromJson(needs.detect-team.outputs.team)}}
-    if: ${{fromJson(needs.detect-team.outputs.team)}}
+    # We don’t want CI to fail, when no groupN.py file has been defined, but we
+    # still want to inform the user about this.  Our appraoch is to set the name
+    # of the run-pelita action from the detect-python.
+    name: ${{ fromJson(needs.detect-team.outputs.status) }}
+    # Ideally, we would skip the rest of the action here with an if: clause,
+    # if: ${{ fromJson(needs.detect-team.outputs.team) }}
+    # but this would mean that the expression in name: doesn’t get evaulated either.
+    # Therefore we skip on every single step below.
     needs: detect-team
     runs-on: ubuntu-latest
     strategy:
@@ -47,17 +62,21 @@ jobs:
 
     steps:
     - uses: actions/checkout@v2
+      if: ${{ fromJson(needs.detect-team.outputs.team) }}
     - name: Set up Python ${{ matrix.python-version }}
+      if: ${{ fromJson(needs.detect-team.outputs.team) }}
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}
     - name: Install dependencies
+      if: ${{ fromJson(needs.detect-team.outputs.team) }}
       run: |
         python -m pip install --upgrade pip
         python -m pip install flake8 pytest
         python -m pip install git+https://github.com/ASPP/pelita
         if [ -f requirements.txt ]; then pip install -r requirements.txt; fi
     - name: Check that a the team can be imported
+      if: ${{ fromJson(needs.detect-team.outputs.team) }}
       run: |
         pelita --check-team ${{needs.detect-team.outputs.team}}
 


### PR DESCRIPTION
Adding Github Actions.

There are three actions defined:

* A simple pytest run on the whole repo
* An action to detect whether a groupN.py file has been created
* Depending on the outcome of the second action: Run `pelita --check-team` with that file so that we know that at least the import mechanism works. (At some point, we can add another action that plays an actual game here.)

There are no hard failures when no groupN.py file has been created so as not to annoy the students with CI breakage for the first two days. I hope that the title of the action makes it clear enough that something is bad.

<img width="867" alt="image" src="https://user-images.githubusercontent.com/216179/126897968-b80274c3-38dd-402a-b9e1-3a47739c7e17.png">
