### PR TITLE
BLD: Adding .gitignore from main pelita repo

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,33 +1,57 @@
-# Byte-compiled / optimized / DLL files
+# We provide a set of user specific ignores here.
+# A pragmatic approach to preventing erroneous adding.
+
+# python ignores
 __pycache__/
 *.py[cod]
-*$py.class
 
-
-# Unit test / coverage reports
-htmlcov/
-.tox/
-.coverage
-.coverage.*
-.cache
-nosetests.xml
-coverage.xml
-*.cover
-.hypothesis/
+# pytest
 .pytest_cache/
 
-# Jupyter Notebook
+# ipython notebook
 .ipynb_checkpoints
 
-# pyenv
-.python-version
+# coverage ignore
+.coverage
 
-# Spyder project settings
-.spyderproject
+# editors
+.project
+.classpath
+.settings
+.metadata
+.pydevproject
+.cache
+.idea
+.vscode
 .spyproject
 
-# other
-.*.swp
 
-# macOS
-.DS_Store
+# other generic files to ignore
+*~
+*.lock
+*.DS_Store
+*.swp
+*.out
+
+.cache
+
+# Distribution / packaging
+.Python
+build/
+develop-eggs/
+dist/
+downloads/
+eggs/
+.eggs/
+lib/
+lib64/
+parts/
+sdist/
+var/
+wheels/
+*.egg-info/
+.installed.cfg
+*.egg
+
+
+pelita.log


### PR DESCRIPTION
Probably doesn’t make much sense in having two separate gitignore files. If something is missing in one of them, we should be adding it to the other as well.